### PR TITLE
Jspm as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   "author": "Guy Griffiths",
   "license": "ISC",
   "devDependencies": {
-    "http-server": "^0.9.0",
-    "jspm": "^0.16.48"
+    "http-server": "^0.9.0"
   },
+  "peerDependencies": {
+    "jspm": "^0.16.48"
+  }
   "jspm": {
     "directories": {
       "baseURL": "public",


### PR DESCRIPTION
I think JSPM should be a peer dependency since it's required by the `postinstall` script. 
We could otherwise also separate the JSPM script from `postinstall` script